### PR TITLE
Автоматизируй это

### DIFF
--- a/app/classes/model/Task.php
+++ b/app/classes/model/Task.php
@@ -1,4 +1,9 @@
 <?php
+
+namespace App\Classes\Model;
+
+use phpDocumentor\Reflection\Types\Nullable;
+
 class Task
 {
     const STATUS_NEW = 'new';
@@ -17,14 +22,14 @@ class Task
     private $customerId;
     private $status;
 
-    public function __construct($status, $customerId, $executorId = null)
+    public function __construct(string $status, int $customerId, ?int $executorId = null)
     {
         $this->status     = $status;
         $this->executorId = $executorId;
         $this->customerId = $customerId;
     }
 
-    public function getStatusesMap()
+    public function getStatusesMap(): array
     {
         return [
             self::STATUS_NEW => 'Новое',
@@ -35,7 +40,7 @@ class Task
         ];
     }
 
-    public function getActionsMap()
+    public function getActionsMap(): array
     {
         return [
             self::ACTION_START  => 'Задание опубликовано, исполнитель ещё не найден',
@@ -46,7 +51,7 @@ class Task
         ];
     }
 
-    public function getStatusByAction($actionName)
+    public function getStatusByAction(string $actionName): ?string
     {
         switch($actionName) {
             case self::ACTION_START:
@@ -70,7 +75,7 @@ class Task
 
     }
 
-    public function getAvailableActions($currentUserId)
+    public function getAvailableActions(int $currentUserId): array
     {
         switch($this->status) {
             case self::STATUS_NEW:

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,15 @@
 {
-    "require-dev": {
-        "phpunit/phpunit": "^9.5"
+  "require-dev": {
+    "phpunit/phpunit": "^9.5"
+  },
+  "autoload": {
+    "psr-4": {
+      "App\\": "app/"
     }
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "Tests\\": "tests/"
+    }
+  }
 }

--- a/index.php
+++ b/index.php
@@ -1,0 +1,7 @@
+<?php
+
+require_once "vendor/autoload.php";
+
+use App\Classes\Model\Task;
+
+$task = new Task('new', 1, 2);

--- a/tests/Unit/ExampleTest.php
+++ b/tests/Unit/ExampleTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Unit;
+namespace Unit;
 
 use PHPUnit\Framework\TestCase;
 

--- a/tests/Unit/TaskTest.php
+++ b/tests/Unit/TaskTest.php
@@ -1,32 +1,50 @@
 <?php
 
-namespace Tests\Unit;
+namespace Unit;
 
 use PHPUnit\Framework\TestCase;
-use Task;
-
-require __DIR__ . '/../../classes/Task.php';
+use App\Classes\Model\Task;
 
 class TaskTest extends TestCase
 {
+    const TEST_CUSTOMER_ID = 1;
+    const TEST_EXECUTOR_ID = 2;
+    const TEST_RANDOM_USER_ID = 3;
+
     public function testGetStatusByAction()
     {
         $task = new Task(Task::STATUS_NEW, 1, 2);
         $this->assertEquals(Task::STATUS_CANCELLED, $task->getStatusByAction(Task::ACTION_CANCEL));
     }
 
-    public function testGetAvailableActions()
+    public function testActionsStart()
     {
-        $customerId = 1;
-        $executorId = 2;
-        $randomUserId = 3;
-        $task = new Task(Task::STATUS_NEW, $customerId);
-        $this->assertEquals([Task::ACTION_START, Task::ACTION_CANCEL], $task->getAvailableActions($customerId));
-        $this->assertEquals([Task::ACTION_RESPOND], $task->getAvailableActions($randomUserId));
-
-        $task = new Task(Task::STATUS_WORK, $customerId, $executorId);
-        $this->assertEquals([Task::ACTION_COMPLETE], $task->getAvailableActions($customerId));
-        $this->assertEquals([Task::ACTION_FAIL], $task->getAvailableActions($executorId));
-        $this->assertEquals([], $task->getAvailableActions($randomUserId));
+        $task = new Task(Task::STATUS_NEW, self::TEST_CUSTOMER_ID);
+        $this->assertEquals([Task::ACTION_START, Task::ACTION_CANCEL], $task->getAvailableActions(self::TEST_CUSTOMER_ID));
     }
+
+    public function testActionsRespond()
+    {
+        $task = new Task(Task::STATUS_NEW, self::TEST_CUSTOMER_ID);
+        $this->assertEquals([$task::ACTION_START, $task::ACTION_CANCEL], $task->getAvailableActions(self::TEST_CUSTOMER_ID));
+    }
+
+    public function testActionsComplete()
+    {
+        $task = new Task(Task::STATUS_WORK, self::TEST_CUSTOMER_ID, self::TEST_EXECUTOR_ID);
+        $this->assertEquals([Task::ACTION_COMPLETE], $task->getAvailableActions(self::TEST_CUSTOMER_ID));
+    }
+
+    public function testActionsFail()
+    {
+        $task = new Task(Task::STATUS_WORK, self::TEST_CUSTOMER_ID, self::TEST_EXECUTOR_ID);
+        $this->assertEquals([Task::ACTION_FAIL], $task->getAvailableActions(self::TEST_EXECUTOR_ID));
+    }
+
+    public function testActionsForRandomUser()
+    {
+        $task = new Task(Task::STATUS_WORK, self::TEST_CUSTOMER_ID, self::TEST_EXECUTOR_ID);
+        $this->assertEquals([], $task->getAvailableActions(self::TEST_RANDOM_USER_ID));
+    }
+
 }


### PR DESCRIPTION
При установке неймспейсов для проекта, я добавил корневой namespace для папки Tests в файле composer.json, для того чтобы  namespace моего файла tests/Unit/TaskTest.php выглядел таким образом: Tests\Unit. Однако, мой IDE подчеркивает этот namespace и говорит что правильный namespace Unit. Не могли Вы пояснить почему так происходит, пожалуйста?

---
:mortar_board: [Автоматизируй это](https://up.htmlacademy.ru/yii/2/user/809925/tasks/4)